### PR TITLE
fix/re-register error

### DIFF
--- a/app/anime/[id]/page.tsx
+++ b/app/anime/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { AnimeDetail } from "@/app/features/animeDetail/AnimeDetail";
-import { notFound } from "next/navigation";
 
 type AnimePageProps = {
   params: { id: string };
@@ -7,7 +6,6 @@ type AnimePageProps = {
 
 export default async function AnimePage({ params }: AnimePageProps) {
   const id = parseInt(params.id, 10);
-   if (isNaN(id)) notFound();
 
    return <AnimeDetail id={id} />
 }

--- a/app/components/register/Register.tsx
+++ b/app/components/register/Register.tsx
@@ -4,7 +4,7 @@ import { registerAnime } from "@/app/lib/actions/resisterAnime";
 import { useState, useTransition } from "react";
 import { RegisterType } from "@/app/types/types";
 import toast from "react-hot-toast";
-import styles from "../top.module.css";
+import styles from "./register.module.css";
 const { registerButton, isRegisteredLabel } = styles;
 
 export const Register = (props: RegisterType) => {

--- a/app/components/register/register.module.css
+++ b/app/components/register/register.module.css
@@ -1,0 +1,19 @@
+.isRegisteredLabel {
+  color: #ddd;
+  grid-area: 2/2/3/3;
+}
+.registerButton {
+  border-radius: 4px;
+  padding: 0.3em 0.8em;
+  color: #fff;
+  font-weight: 500;
+  grid-area: 2/2/3/3;
+  position: relative;
+  isolation: isolate;
+  z-index: 10;
+  background-color: var(--primary-c);
+  transition: background-color 0.4s;
+  &:hover {
+    background-color: #333;
+  }
+}

--- a/app/features/animeDetail/AnimeDetail.tsx
+++ b/app/features/animeDetail/AnimeDetail.tsx
@@ -1,52 +1,145 @@
 import { getSeason } from "@/app/hooks/getSeason";
 import { prisma } from "@/app/lib/prisma";
 import Image from "next/image";
-import { notFound } from "next/navigation";
+import { RatingClient } from "./RatingClient";
+import { FaCircleUser } from "react-icons/fa6";
+import styles from "./animeDetail.module.css";
+import { Register } from "../../components/register/Register";
+import { getServerSession } from "next-auth";
+import { nextAuthOptions } from "@/app/lib/next-auth/options";
+const {
+  card,
+  dataArea,
+  seasonArea,
+  row,
+  reviewArea,
+  noReview,
+  isRegisteredLabel,
+  registerArea,
+} = styles;
 
 export const AnimeDetail = async ({ id }: { id: number }) => {
+  const session = await getServerSession(nextAuthOptions);
+  const userId = session?.user?.id;
+
   const anime = await prisma.anime.findUnique({
     where: { id },
     include: {
       userAnime: true,
-      reviews: true,
+      reviews: {
+        include: {
+          user: true,
+        },
+      },
     },
   });
 
-  if (!anime) notFound();
+  const isRegistered = !!(await prisma.userAnime.findUnique({
+    where: {
+      userId_animeId: {
+        userId: userId!,
+        animeId: id,
+      },
+    },
+  }));
+
+  if (!anime)
+    return (
+      <section>
+        <p>指定のアニメは存在しません。</p>
+      </section>
+    );
 
   const { title, seasonName, seasonYear, imageUrl, userAnime, reviews } = anime;
 
-  const totalRegistered = userAnime.length;
+  const ratedReviews = reviews.filter(
+    (r) => r.rating !== null && r.rating !== undefined
+  );
   const averageRating =
-    reviews.length > 0
+    ratedReviews.length > 0
       ? (
-          reviews.reduce((sum, r) => sum + (r.rating ?? 0), 0) / reviews.length
+          ratedReviews.reduce((sum, r) => sum + (r.rating ?? 0), 0) /
+          ratedReviews.length
         ).toFixed(1)
       : null;
 
   return (
     <section>
-      <h1>{title}</h1>
-      {seasonYear && <p>{seasonYear}年</p>}
-      {seasonName && <p>{getSeason(seasonName)}</p>}
-      {imageUrl && <Image src={imageUrl} alt={title} width={300} height={100} />}
-      <p>登録ユーザー数: {totalRegistered}人</p>
-      <p>平均評価: {averageRating ?? "未評価"}</p>
-
-      <div>
-        <h2>レビュー</h2>
-        {reviews.length > 0 ? (
-          <ul>
-            {reviews.map((review) => (
-              <li key={review.id}>
-                <p>⭐ {review.rating ?? "なし"}</p>
-                <p>{review.comment ?? "コメントなし"}</p>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>レビューはまだありません。</p>
+      <div className={card}>
+        {imageUrl && (
+          <Image src={imageUrl} alt={title} width={300} height={100} />
         )}
+        <div className={dataArea}>
+          <h2>{title}</h2>
+          <div className={seasonArea}>
+            {seasonYear && <p>{seasonYear}年</p>}
+            {seasonName && <p>{getSeason(seasonName)}</p>}
+          </div>
+          <dl>
+            <div className={row}>
+              <dt>登録ユーザー数</dt>
+              <dd>{userAnime.length}人</dd>
+            </div>
+            <div className={row}>
+              <dt>レビュー数</dt>
+              <dd>{reviews.length}</dd>
+            </div>
+            <div className={row}>
+              <dt>みんなの評価</dt>
+              <dd>
+                {averageRating ? (
+                  `星 ${averageRating}`
+                ) : (
+                  <span className={noReview}>評価はまだありません</span>
+                )}
+                <br />
+                <RatingClient value={Number(averageRating)} />
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className={reviewArea}>
+          <h3>みんなのレビュー</h3>
+          {reviews.length > 0 ? (
+            <ul>
+              {reviews.map((review) => (
+                <li key={review.id}>
+                  <div>
+                    {review.user.image ? (
+                      <Image
+                        width={50}
+                        height={50}
+                        alt="profile-icon"
+                        src={review.user.image}
+                      />
+                    ) : (
+                      <FaCircleUser />
+                    )}
+                    <span>{review.user.name ?? "ゲスト"}</span>
+                    <RatingClient value={Number(review.rating)} />
+                  </div>
+                  <p>{review.comment}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className={noReview}>レビューはまだありません。</p>
+          )}
+        </div>
+        <div className={registerArea}>
+        {isRegistered ? (
+          <p className={isRegisteredLabel}>登録済み</p>
+        ) : (
+          <Register
+            id={id}
+            title={title}
+            seasonYear={seasonYear}
+            seasonName={seasonName}
+            imageUrl={imageUrl}
+          />
+        )}
+        </div>
       </div>
     </section>
   );

--- a/app/features/animeDetail/RatingClient.tsx
+++ b/app/features/animeDetail/RatingClient.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import StarRatings from "react-star-ratings";
+
+type Props = {
+  value: number;
+};
+
+export const RatingClient = ({ value }: Props) => (
+  <StarRatings
+    rating={Number(value)}
+    starRatedColor="gold"
+    numberOfStars={5}
+    starDimension="25px"
+    starSpacing="2px"
+  />
+);

--- a/app/features/animeDetail/animeDetail.module.css
+++ b/app/features/animeDetail/animeDetail.module.css
@@ -1,0 +1,98 @@
+.card {
+  padding: max(3vw, 1em);
+  border-radius: 10px;
+  background-color: rgb(0 0 0/0.4);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: #fff;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1em max(3vw, 1em);
+  & > img {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 16/9;
+    object-fit: cover;
+    border-radius: 10px;
+  }
+  & h2 {
+    font-weight: 500;
+    font-size: max(1.4vw, 1em);
+    margin-bottom: 4px;
+  }
+  & h3 {
+    font-weight: 500;
+  }
+}
+.dataArea {
+  & dl {
+    background-color: #00000031;
+    border-radius: 4px;
+    margin-top: 10px;
+  }
+}
+.seasonArea {
+  display: flex;
+  gap: 10px;
+  justify-content: end;
+}
+
+.row {
+  padding: 0.6em 0.8em;
+  display: flex;
+  font-weight: 500;
+  & ~ .row {
+    border-top: 1px solid rgb(255 255 255/0.2);
+  }
+  & dt {
+    width: 9em;
+    color: #ccc;
+  }
+}
+.reviewArea {
+  grid-area: 2/1/3/3;
+  & ul {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  & li {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 6px;
+    margin-top: 10px;
+    padding: 0.6em 0.8em;
+    & > div {
+      display: flex;
+      gap: 1em;
+      align-items: center;
+      margin-bottom: 6px;
+      & img {
+        width: 40px;
+        height: auto;
+        aspect-ratio: 1;
+        border-radius: 50%;
+        object-fit: cover;
+      }
+      & > div {
+        margin-left: auto;
+      }
+    }
+    & > p {
+      white-space: pre-line;
+    }
+  }
+}
+.noReview {
+  display: inline-block;
+  transform: skew(-20deg);
+  font-weight: 500;
+  color: #aaa;
+}
+.isRegisteredLabel {
+  color: #ddd;
+  grid-area: 2/2/3/3;
+}
+.registerArea {
+  grid-area: 3/1/4/3;
+  justify-self: end;
+}

--- a/app/features/myPage/components/editModal/EditModal.tsx
+++ b/app/features/myPage/components/editModal/EditModal.tsx
@@ -1,7 +1,7 @@
 import { Thumbnail } from "@/app/components/Thumbnail";
 import { FormResult, ReviewDataType, StatusType } from "@/app/types/types";
-import { Rating } from "react-simple-star-rating";
 import { startTransition, useActionState, useEffect, useState } from "react";
+import StarRatings from "react-star-ratings";
 import { IoCloseCircle } from "react-icons/io5";
 import { FaCircleCheck } from "react-icons/fa6";
 import styles from "./editModal.module.css";
@@ -52,10 +52,6 @@ export const EditModal = ({
     }
   }, [formState, toggleModal, hasShownToast, onUpdate]);
 
-  const handleRating = (rate: number) => {
-    setRating(rate);
-  };
-
   return (
     <div className={`${modal} ${isOpen ? open : ""}`}>
       <form action={formAction}>
@@ -72,11 +68,14 @@ export const EditModal = ({
             </select>
           </div>
           <div className={ratingArea}>
-            <Rating
-              onClick={handleRating}
-              initialValue={ratingState}
-              allowHover
-              size={25}
+            <StarRatings
+              rating={ratingState}
+              starRatedColor="gold"
+              starHoverColor="orange"
+              numberOfStars={5}
+              changeRating={(newRating) => setRating(newRating)}
+              starDimension="25px"
+              starSpacing="2px"
             />
             {ratingState !== 0 && <span>星{ratingState}つ</span>}
           </div>

--- a/app/features/myPage/components/myAnime/MyAnime.tsx
+++ b/app/features/myPage/components/myAnime/MyAnime.tsx
@@ -11,7 +11,7 @@ import { deleteAnime } from "@/app/lib/actions/deleteAnime";
 import toast from "react-hot-toast";
 import { EditModal } from "../editModal/EditModal";
 import { ModalPortal } from "../ModalPortal";
-import { Rating } from "react-simple-star-rating";
+import StarRatings from 'react-star-ratings'
 import { getStatus } from "@/app/hooks/getStatus";
 const { body, row, commentBox, noReview, buttons, toolTip } = styles;
 
@@ -22,7 +22,6 @@ export const MyAnime = ({
   imageUrl,
   seasonYear,
   seasonName,
-  registerId,
   status,
   rating,
   comment,
@@ -31,7 +30,7 @@ export const MyAnime = ({
   const [isRegistered, setIsRegistered] = useState(true);
   const handleDelete = () => {
     startTransition(async () => {
-      const promise = deleteAnime(registerId);
+      const promise = deleteAnime(userId, id);
       toast.promise(promise, {
         loading: "削除中...",
         success: "My Pageから削除しました",
@@ -66,11 +65,11 @@ export const MyAnime = ({
         <Thumbnail imageUrl={imageUrl} title={title} />
         <h3>{title}</h3>
         <div className={row}>
+          <span>{getStatus(reviewState.status)}</span>
           <div>
             {seasonYear && <span>{`${seasonYear}年`}</span>}
             {seasonName && <span>{getSeason(seasonName)}</span>}
           </div>
-          {reviewState.status && <span>{getStatus(reviewState.status)}</span>}
         </div>
 
         <h4>レビュー</h4>
@@ -79,11 +78,12 @@ export const MyAnime = ({
         ) : (
           <p className={noReview}>レビューはまだ書かれていません。</p>
         )}
-        <Rating
-          initialValue={reviewState.rating}
-          size={25}
-          readonly
-          allowHover={false}
+        <StarRatings
+          rating={reviewState.rating}
+          starRatedColor="gold"
+          numberOfStars={5}
+          starDimension='25px'
+          starSpacing="2px"
         />
         <div className={buttons}>
           <button type="button" onClick={toggleModal}>

--- a/app/features/myPage/components/myAnime/myAnime.module.css
+++ b/app/features/myPage/components/myAnime/myAnime.module.css
@@ -1,5 +1,4 @@
 .body {
-  gap: max(3vw, 1em);
   padding: max(3vw, 1em);
   border-radius: 10px;
   background-color: rgb(0 0 0/0.4);
@@ -31,6 +30,7 @@
   > div {
     display: flex;
     gap: 10px;
+    
   }
   > span {
     background-color: #fff;
@@ -67,7 +67,6 @@
     aspect-ratio: 1;
     position: relative;
     border-radius: 3px;
-
     & svg {
       font-size: 1.2em;
       transition: color 0.4s;
@@ -84,6 +83,7 @@
     }
   }
 }
+
 .toolTip {
   position: absolute;
   white-space: nowrap;

--- a/app/features/top/components/Anime.tsx
+++ b/app/features/top/components/Anime.tsx
@@ -19,11 +19,17 @@ export const Anime = async (props: AnimeType) => {
       }))
     : false;
 
+  const existsInAnime = !!(await prisma.anime.findUnique({
+    where: { id: props.annictId },
+    select: { id: true },
+  }));
+
   return (
     <AnimeCard
       {...props}
       isLoggedIn={!!session}
       isRegistered={isRegistered}
+      existsInAnime={existsInAnime}
     />
   );
 };

--- a/app/features/top/components/AnimeCard.tsx
+++ b/app/features/top/components/AnimeCard.tsx
@@ -1,16 +1,17 @@
-'use client'
+"use client";
 
-import { Register } from "./Register";
+import { Register } from "@/app/components/register/Register";
 import { AnimeType } from "@/app/types/types";
 import { getSeason } from "@/app/hooks/getSeason";
 import Link from "next/link";
 import styles from "../top.module.css";
 import { Thumbnail } from "@/app/components/Thumbnail";
-const { isRegisteredLabel, body, linkLogin } = styles;
+const { isRegisteredLabel, body, linkCover, linkLogin } = styles;
 
 type AnimeCardProps = AnimeType & {
   isRegistered: boolean;
   isLoggedIn: boolean;
+  existsInAnime: boolean;
 };
 
 export const AnimeCard = ({
@@ -21,11 +22,15 @@ export const AnimeCard = ({
   seasonName,
   isRegistered,
   isLoggedIn,
+  existsInAnime,
 }: AnimeCardProps) => {
-
   const getRegister = () => {
     if (!isLoggedIn) {
-      return <Link href={"/login"} className={linkLogin}>ログインして登録</Link>;
+      return (
+        <Link href={"/login"} className={linkLogin}>
+          ログインして登録
+        </Link>
+      );
     }
     if (isRegistered) {
       return <p className={isRegisteredLabel}>登録済み</p>;
@@ -44,6 +49,9 @@ export const AnimeCard = ({
     <li key={annictId}>
       <Thumbnail imageUrl={image?.facebookOgImageUrl} title={title} />
       <div className={body}>
+        {existsInAnime && (
+          <Link href={`/anime/${annictId}`} className={linkCover}></Link>
+        )}
         <h2>{title}</h2>
         <div>
           {seasonYear && <span>{`${seasonYear}年`}</span>}

--- a/app/features/top/top.module.css
+++ b/app/features/top/top.module.css
@@ -1,30 +1,3 @@
-.searchArea {
-  display: flex;
-  justify-content: center;
-  gap: 1em;
-  & label {
-    box-shadow: 0 8px 16px rgb(0 0 0/0.2);
-    display: flex;
-    align-items: center;
-    width: min(100%, 340px);
-    border-radius: 2em;
-    overflow: hidden;
-    background-color: #fff;
-  }
-  & input {
-    padding: 0.5em 0.6em;
-    flex: 1;
-  }
-}
-
-.iconBox {
-  height: 100%;
-  display: grid;
-  padding-inline: 0.8em 0.5em;
-  place-items: center;
-  cursor: pointer;
-}
-
 .noAnime {
   width: fit-content;
   margin: max(5vw, 50px) auto 0;
@@ -36,9 +9,7 @@
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
 }
-
 .resultList {
-  padding-top: max(5vw, 50px);
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 5vw;
@@ -51,6 +22,13 @@
     color: #fff;
     display: flex;
     flex-direction: column;
+    position: relative;
+    transition-property: translate, box-shadow;
+    transition-duration: .4s;
+    &:has(.linkCover:hover) {
+      translate: 0 -14px;
+      box-shadow: 0 10px 20px rgb(0 0 0/0.3);
+    }
   }
   & img {
     width: 100%;
@@ -59,6 +37,35 @@
     object-fit: cover;
   }
 }
+
+.searchArea {
+  position: fixed;
+  inset: max(5vw, 50px) auto auto 5vw;
+  z-index: 100;
+  & label {
+    box-shadow: 0 8px 16px rgb(0 0 0/0.2);
+    display: flex;
+    align-items: center;
+    width: var(--header-w);
+    border-radius: 2em;
+    overflow: hidden;
+    background-color: #fff;
+  }
+  & input {
+    width: 100%;
+    padding: 0.5em 0.6em;
+    flex: 1;
+  }
+}
+.iconBox {
+  height: 100%;
+  display: grid;
+  padding-inline: 0.8em 0.5em;
+  place-items: center;
+  cursor: pointer;
+}
+
+
 .body {
   flex: 1;
   display: grid;
@@ -76,30 +83,28 @@
     align-self: end;
   }
 }
-
+.linkCover {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
 .isRegisteredLabel {
   color: #ddd;
   grid-area: 2/2/3/3;
 }
-.registerButton,
 .linkLogin {
   border-radius: 4px;
   padding: 0.3em 0.8em;
   color: #fff;
   font-weight: 500;
   grid-area: 2/2/3/3;
-}
-.linkLogin {
+  position: relative;
+  isolation: isolate;
+  z-index: 10;
   background-color: #333;
   transition: opacity 0.4s;
   &:hover {
     opacity: 0.7;
   }
 }
-.registerButton {
-  background-color: var(--primary-c);
-  transition: background-color 0.4s;
-  &:hover {
-    background-color: #333;
-  }
-}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -66,7 +66,7 @@ main {
   min-height: 100vh;
   margin-left: calc(var(--header-w) + 5vw);
   /* flex: 1; */
-  & *:nth-child(n + 2) {
+  & > *:nth-child(n + 2) {
     isolation: isolate;
   }
 }

--- a/app/lib/actions/deleteAnime.ts
+++ b/app/lib/actions/deleteAnime.ts
@@ -2,8 +2,18 @@
 
 import { prisma } from "@/app/lib/prisma";
 
-export const deleteAnime = async (id : string ) => {
-  return await prisma.userAnime.delete({
-    where: { id },
-  });
+export const deleteAnime = async (userId: string, animeId: number) => {
+  return await prisma.$transaction([
+    prisma.review.deleteMany({
+      where: { userId, animeId },
+    }),
+    prisma.status.deleteMany({
+      where: { userId, animeId },
+    }),
+    prisma.userAnime.delete({
+      where: {
+        userId_animeId: { userId, animeId },
+      },
+    }),
+  ]);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
-        "react-simple-star-rating": "^5.1.7",
         "react-spinners": "^0.15.0",
+        "react-star-ratings": "^2.3.0",
         "three": "^0.175.0",
         "zod": "^3.24.2"
       },
@@ -33,6 +33,7 @@
         "@types/node": "20.17.30",
         "@types/react": "19.1.0",
         "@types/react-dom": "^19",
+        "@types/react-star-ratings": "^2.3.3",
         "@types/three": "^0.175.0",
         "eslint": "^9",
         "eslint-config-next": "15.2.4",
@@ -1589,6 +1590,16 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-star-ratings": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-star-ratings/-/react-star-ratings-2.3.3.tgz",
+      "integrity": "sha512-8vLqJG1uRA2SmYBBMPWpv6QWHLvZ/a3XmELCIf4xh4VFXT7QkkrcthiLSMjQ4ibDiUtYYpyLB0JoR1lBHSHA2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.3",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
@@ -2548,6 +2559,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -4435,7 +4452,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4572,7 +4588,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4806,7 +4821,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5293,7 +5307,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5389,7 +5402,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-reconciler": {
@@ -5407,19 +5419,6 @@
         "react": "^19.0.0"
       }
     },
-    "node_modules/react-simple-star-rating": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/react-simple-star-rating/-/react-simple-star-rating-5.1.7.tgz",
-      "integrity": "sha512-NTFkW8W3uwvI82Fv7JW5i7gmDjEZKxJmj+Z9vn+BjYIXT6ILdnU9qnSUP2cWrWN/WAUlue81f9SgM4CQcenltQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      }
-    },
     "node_modules/react-spinners": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.15.0.tgz",
@@ -5428,6 +5427,31 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-star-ratings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-star-ratings/-/react-star-ratings-2.3.0.tgz",
+      "integrity": "sha512-34Z/oFNDRRn4ZcX7F3t9ccnpo7SQ32gD/vsusQOBc6B6vlqaGR6tke1/Yx3jTDjemKRSmXqhKgpPTR7/JAXq6A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "classnames": "^2.2.1",
+        "prop-types": "^15.6.0",
+        "react": "^16.1.0"
+      }
+    },
+    "node_modules/react-star-ratings/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-use-measure": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
-    "react-simple-star-rating": "^5.1.7",
     "react-spinners": "^0.15.0",
+    "react-star-ratings": "^2.3.0",
     "three": "^0.175.0",
     "zod": "^3.24.2"
   },
@@ -34,6 +34,7 @@
     "@types/node": "20.17.30",
     "@types/react": "19.1.0",
     "@types/react-dom": "^19",
+    "@types/react-star-ratings": "^2.3.3",
     "@types/three": "^0.175.0",
     "eslint": "^9",
     "eslint-config-next": "15.2.4",


### PR DESCRIPTION
MyAnimeから削除した際、再び同じ作品を登録しようとするとAnimeに紐付いたReviewやStatusは削除されてないため、schemaに定義した  @@unique([userId, animeId])という１Userが１Animeに持てるreviewとstatusは１つだけという制約に反してエラーになるバグを解消しました。
エラーにschemaの制約でAnimeが削除された時とUserが削除された時はリレーションのあるテーブルのrecordが削除されるようにはなってますが、UserAnimeにschema側で同様の制約を課す書き方はない（ReviewやStatusを外部キーとして持ってない）ので、MyAnime(UserAnime)から削除した際にReviewとStatusテーブルからもこのuserのこのanimeに紐付いたrecordを削除する処理を加えました。